### PR TITLE
Increase contrast according to WCAG 2.0

### DIFF
--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -14,7 +14,7 @@ body {
 ------------------------------------------------------------------ */
 
 .nav-wrapper {
-    background:#ee3243; /* unired */
+    background:#E71324; /* unired */
     border-bottom:1px solid #1D2730 !important;
 }
 
@@ -197,11 +197,11 @@ body {
 
 /* Carousel overrides */
 .carousel-indicators li {
-    border:1px solid #ee3243;
+    border:1px solid #E71324;
 }
 
 .carousel-indicators .active {
-    background-color:#ee3243;
+    background-color:#E71324;
 }
 
 .item img {

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -421,3 +421,12 @@ footer#footer .photo-by {
 .center-text {
     text-align:center;
 }
+
+.link-text {
+    color: #2A6293;
+}
+
+/* Overrides Bootstrap's primary button color */
+.btn-primary {
+    background-color: #3277B3 !important;
+}

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -422,7 +422,7 @@ footer#footer .photo-by {
     text-align:center;
 }
 
-.link-text {
+a {
     color: #2A6293;
 }
 


### PR DESCRIPTION
Increased contrast to 4.5:1 for small text in order to comply with WCAG 2.0 - 1.4.3

NB! When using automated tools for contrast checks (f.e. Wave extension in Chrome), they report additional contrast error. This error is misleading since the tool checks for the contact of the same element, so the contrast is always 1:1. 