### PR TITLE
Fix headings in accordance with WCAG

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -178,7 +178,7 @@
                     {{ range first 1 .Sections }}
                     {{ range first 1 .CurrentSection.Pages }}
 
-                    <h2 class="super-heading">Download</h2>
+                    <h2 class="super-heading">Download NAV</h2>
                     <p>NAV is freely available under the GNU GPL license and can run on any UNIX machine that supports Apache and Python*</p>
                     <p class="bottom-space">The latest version is <span style="font-weight:400;">{{ .Title }}</span>. Choose between our installation alternatives.</p>
                     <div class="row">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,6 +25,9 @@
         </div>
         <div id="features" class="container content">
             <div class="row">
+                <div class="col-md-12">
+                    <h2 class="super-heading">Features</h2>
+                </div>
                 <div class="card col-md-6">
                     <div class="row">
                         <div class="col-md-2 col-sm-2 col-xs-3">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -109,7 +109,7 @@
             <div class="container">
                 <div class="row">
                     <div class="col-md-12">
-                        <h1 class="super-heading">About NAV</h1>
+                        <h2 class="super-heading">About NAV</h2>
                     </div>
                 </div>
                 <div class="row">
@@ -178,7 +178,7 @@
                     {{ range first 1 .Sections }}
                     {{ range first 1 .CurrentSection.Pages }}
 
-                    <h1 class="super-heading">Download</h1>
+                    <h2 class="super-heading">Download</h2>
                     <p>NAV is freely available under the GNU GPL license and can run on any UNIX machine that supports Apache and Python*</p>
                     <p class="bottom-space">The latest version is <span style="font-weight:400;">{{ .Title }}</span>. Choose between our installation alternatives.</p>
                     <div class="row">
@@ -241,7 +241,7 @@
         <div id="tour" class="container content">
             <div class="row">
                 <div class="col-md-12">
-                    <h1 class="super-heading">Take a tour</h1>
+                    <h2 class="super-heading">Take a tour</h2>
                     <figure>
                         <iframe width="500" height="281" src="https://www.youtube.com/embed/eYYy1VLDm54?feature=oembed&amp;rel=0&amp;showinfo=0&amp;controls=1&amp;hd=1" frameborder="0" allowfullscreen=""></iframe>
                     </figure>
@@ -252,7 +252,7 @@
         <div id="who" class="container content">
             <div class="row">
                 <div class="col-md-12">
-                    <h1 class="super-heading">Who uses NAV?</h1>
+                    <h2 class="super-heading">Who uses NAV?</h2>
                 </div>
             </div>
             <div class="row bottom-space">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,7 +26,7 @@
         <div id="features" class="container content">
             <div class="row">
                 <div class="col-md-12">
-                    <h2 class="super-heading">Features</h2>
+                    <h2 hidden class="super-heading">Features</h2>
                 </div>
                 <div class="card col-md-6">
                     <div class="row">

--- a/themes/navsite/layouts/_default/baseof.html
+++ b/themes/navsite/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="en">
     {{- partial "head.html" . -}}
     <body>
-        <h1 hidden></h1>
+        <h1 hidden>NAV</h1>
         {{- partial "header.html" . -}}
         <div id="content">
         {{- block "main" . }}{{- end }}

--- a/themes/navsite/layouts/_default/baseof.html
+++ b/themes/navsite/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="en">
     {{- partial "head.html" . -}}
     <body>
+        <h1 hidden></h1>
         {{- partial "header.html" . -}}
         <div id="content">
         {{- block "main" . }}{{- end }}


### PR DESCRIPTION
Following WCAG requirements are satisfied:

- WCAG 2.0 - 1.3.1
- WCAG 2.0 - 2.4.10
- WCAG 2.0 - 2.4.6

In other words:

- One h1 per page (hidden in our case)
- All headings are in logical order and there are no "jumps" between headings (f.e. from h2 to h4)
- HTML headers are not used as a replacement for lists
- All sections have headers
- All headers have descriptive and informative names
- Everything that looks like heading is coded as one