### PR TITLE
Add text description to non-decorative pictures

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -136,10 +136,10 @@
                                     <div class="row">
                                         <div class="col-md-12">
                                             <img class="" src="/image/nav1.png"
-                                                 alt="Screenshot of the NAV's frontpage."
-                                                 aria-describedby="Frontpage of NAV.
-                                                 On the left side there are the 'Getting started with NAV'-section and a top portion of some graph.
-                                                 On the right side there are following sections: NAV blog, Status, Action map"
+                                                 alt="Screenshot of NAV's front page."
+                                                 aria-describedby="Front page of NAV.
+                                                 On the left side there is the 'Getting started with NAV'-section and a top portion of a graph.
+                                                 On the right side there are the following sections: NAV blog, Status, Action map"
                                             >
                                         </div>
                                     </div>
@@ -148,11 +148,11 @@
                                   <div class="row">
                                         <div class="col-md-12">
                                             <img class="" src="/image/nav4.png"
-                                                 alt="Screenshot of the NAV's Geomap page."
+                                                 alt="Screenshot of NAV's Geomap page."
                                                  aria-describedby="NAV's Geomap page.
                                                  Most of the picture is a map of a street. There is line from one building to another.
                                                  The line is half grey and half green.
-                                                 Below the map following metrics is displayed: CPU load, netboxes, Link load, Link capacity."
+                                                 Below the map the following metrics are displayed: CPU load, netboxes, Link load, Link capacity."
                                             >
                                         </div>
                                     </div>
@@ -164,7 +164,7 @@
                                                  alt="Screenshot showing temperature graphs of the sensors of some device."
                                                  aria-describedby="Part of the page showing temperature graphs of the sensors of some device.
                                                  The IP address of the device is blurred out.
-                                                 There are 3 graphs, each shows a current temperature of the sensor and a graph over temperature change below.
+                                                 There are 3 graphs, each shows a current temperature of the sensor and a graph of temperature change below.
                                                  The graphs are called 'Friluftsinntak', 'Over aggregat', 'Over UPS'."
                                             >
                                         </div>
@@ -174,9 +174,9 @@
                                   <div class="row">
                                         <div class="col-md-12">
                                             <img class="" src="/image/nav5.png"
-                                                 alt="Screenshot of graph of the traffic over some port."
+                                                 alt="Screenshot of graph of the traffic on some port."
                                                  aria-describedby="The graph is called 'Port details'.
-                                                 It shows in- and out-traffic over some port measured in bites per second."
+                                                 It shows in- and out-going traffic on some port, measured in bits per second."
                                             >
                                         </div>
                                     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -135,28 +135,49 @@
                                 <div class="item active">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <img class="" src="/image/nav1.png" alt="...">
+                                            <img class="" src="/image/nav1.png"
+                                                 alt="Screenshot of the NAV's frontpage."
+                                                 aria-describedby="Frontpage of NAV.
+                                                 On the left side there are the 'Getting started with NAV'-section and a top portion of some graph.
+                                                 On the right side there are following sections: NAV blog, Status, Action map"
+                                            >
                                         </div>
                                     </div>
                                 </div>
                                 <div class="item">
                                   <div class="row">
                                         <div class="col-md-12">
-                                            <img class="" src="/image/nav4.png" alt="...">
+                                            <img class="" src="/image/nav4.png"
+                                                 alt="Screenshot of the NAV's Geomap page."
+                                                 aria-describedby="NAV's Geomap page.
+                                                 Most of the picture is a map of a street. There is line from one building to another.
+                                                 The line is half grey and half green.
+                                                 Below the map following metrics is displayed: CPU load, netboxes, Link load, Link capacity."
+                                            >
                                         </div>
                                     </div>
                                 </div>
                                 <div class="item">
                                   <div class="row">
                                         <div class="col-md-12">
-                                            <img class="" src="/image/nav6.png" alt="...">
+                                            <img class="" src="/image/nav6.png"
+                                                 alt="Screenshot showing temperature graphs of the sensors of some device."
+                                                 aria-describedby="Part of the page showing temperature graphs of the sensors of some device.
+                                                 The IP address of the device is blurred out.
+                                                 There are 3 graphs, each shows a current temperature of the sensor and a graph over temperature change below.
+                                                 The graphs are called 'Friluftsinntak', 'Over aggregat', 'Over UPS'."
+                                            >
                                         </div>
                                     </div>
                                 </div>
                                 <div class="item">
                                   <div class="row">
                                         <div class="col-md-12">
-                                            <img class="" src="/image/nav5.png" alt="...">
+                                            <img class="" src="/image/nav5.png"
+                                                 alt="Screenshot of graph of the traffic over some port."
+                                                 aria-describedby="The graph is called 'Port details'.
+                                                 It shows in- and out-traffic over some port measured in bites per second."
+                                            >
                                         </div>
                                     </div>
                                 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -135,11 +135,14 @@
                                 <div class="item active">
                                     <div class="row">
                                         <div class="col-md-12">
+                                            <span hidden id="nav1-description">
+                                                Front page of NAV.
+                                                On the left side there is the 'Getting started with NAV'-section and a top portion of a graph.
+                                                On the right side there are the following sections: NAV blog, Status, Action map
+                                            </span>
                                             <img class="" src="/image/nav1.png"
                                                  alt="Screenshot of NAV's front page."
-                                                 aria-describedby="Front page of NAV.
-                                                 On the left side there is the 'Getting started with NAV'-section and a top portion of a graph.
-                                                 On the right side there are the following sections: NAV blog, Status, Action map"
+                                                 aria-describedby="nav1-description"
                                             >
                                         </div>
                                     </div>
@@ -147,12 +150,15 @@
                                 <div class="item">
                                   <div class="row">
                                         <div class="col-md-12">
+                                            <span hidden id="nav4-description">
+                                                NAV's Geomap page.
+                                                Most of the picture is a map of a street. There is line from one building to another.
+                                                The line is half grey and half green.
+                                                Below the map the following metrics are displayed: CPU load, netboxes, Link load, Link capacity.
+                                            </span>
                                             <img class="" src="/image/nav4.png"
                                                  alt="Screenshot of NAV's Geomap page."
-                                                 aria-describedby="NAV's Geomap page.
-                                                 Most of the picture is a map of a street. There is line from one building to another.
-                                                 The line is half grey and half green.
-                                                 Below the map the following metrics are displayed: CPU load, netboxes, Link load, Link capacity."
+                                                 aria-describedby="nav4-description"
                                             >
                                         </div>
                                     </div>
@@ -160,12 +166,15 @@
                                 <div class="item">
                                   <div class="row">
                                         <div class="col-md-12">
+                                            <span hidden id="nav6-description">
+                                                Part of the page showing temperature graphs of the sensors of some device.
+                                                The IP address of the device is blurred out.
+                                                There are 3 graphs, each shows a current temperature of the sensor and a graph of temperature change below.
+                                                The graphs are called 'Friluftsinntak', 'Over aggregat', 'Over UPS'.
+                                            </span>
                                             <img class="" src="/image/nav6.png"
                                                  alt="Screenshot showing temperature graphs of the sensors of some device."
-                                                 aria-describedby="Part of the page showing temperature graphs of the sensors of some device.
-                                                 The IP address of the device is blurred out.
-                                                 There are 3 graphs, each shows a current temperature of the sensor and a graph of temperature change below.
-                                                 The graphs are called 'Friluftsinntak', 'Over aggregat', 'Over UPS'."
+                                                 aria-describedby="nav6-description"
                                             >
                                         </div>
                                     </div>
@@ -173,10 +182,13 @@
                                 <div class="item">
                                   <div class="row">
                                         <div class="col-md-12">
+                                            <span hidden id="nav5-description">
+                                                The graph is called 'Port details'.
+                                                It shows in- and out-going traffic on some port, measured in bits per second.
+                                            </span>
                                             <img class="" src="/image/nav5.png"
                                                  alt="Screenshot of graph of the traffic on some port."
-                                                 aria-describedby="The graph is called 'Port details'.
-                                                 It shows in- and out-going traffic on some port, measured in bits per second."
+                                                 aria-describedby="nav5-description"
                                             >
                                         </div>
                                     </div>


### PR DESCRIPTION
Information bearing pictures must have a text description.

Following requirements are satisfied:

- WCAG 2.0 - 1.1.1
- WCAG 2.0 - 1.4.5