### PR TITLE
Fix overlap on zoom

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,11 +23,10 @@
                 </div>
             </div>
         </div>
-        <div id="features" class="container content">
-            <div class="row">
+        <div id="features" class="container content d-flex">
+
                 <div class="card col-md-6">
-                    <div class="row">
-                        <div class="col-md-2 col-sm-2 col-xs-3">
+                        <div class="col-md-1 col-sm-2 col-xs-3 feature-icon">
                             <span class="fa-stack fa-3x hidden-xs">
                                 <i class="fa fa-square-o fa-stack-2x"></i>
                                 <i class="fa fa-bell-o fa-stack-1x"></i>
@@ -42,11 +41,9 @@
                             <h3>Alerts</h3>
                             <p>If something in the network goes down, NAV alerts you via your dashboard, email or SMS.</p>
                         </div>
-                    </div>
                 </div>
                 <div class="card col-md-6">
-                    <div class="row">
-                        <div class="col-md-2 col-sm-2 col-xs-3">
+                        <div class="col-md-1 col-sm-2 col-xs-3 feature-icon">
                             <span class="fa-stack fa-3x hidden-xs">
                                 <i class="fa fa-square-o fa-stack-2x"></i>
                                 <i class="fa fa-sitemap fa-stack-1x"></i>
@@ -60,13 +57,9 @@
                             <h3>Topology</h3>
                             <p>Devices added to the NAV database can be visualized in several interactive network maps.</p>
                         </div>
-                    </div>
                 </div>
-            </div>
-            <div class="row">
                 <div class="card col-md-6">
-                    <div class="row">
-                        <div class="col-md-2 col-sm-2 col-xs-3">
+                        <div class="col-md-1 col-sm-2 col-xs-3 feature-icon">
                             <span class="fa-stack fa-3x hidden-xs">
                                 <i class="fa fa-square-o fa-stack-2x"></i>
                                 <i class="fa fa-dashboard fa-stack-1x"></i>
@@ -80,11 +73,9 @@
                             <h3>Statistics</h3>
                             <p>NAV gives you VLAN graphs, link loads and customizable reports for your equipment.</p>
                         </div>
-                    </div>
                 </div>
                 <div class="card col-md-6">
-                    <div class="row">
-                        <div class="col-md-2 col-sm-2 col-xs-3">
+                        <div class="col-md-1 col-sm-2 col-xs-3 feature-icon">
                             <span class="fa-stack fa-3x hidden-xs">
                                 <i class="fa fa-square-o fa-stack-2x"></i>
                                 <i class="fa fa-cogs fa-stack-1x"></i>
@@ -98,9 +89,8 @@
                             <h3>Management</h3>
                             <p>Use NAV to monitor your inventory and configure network equipment, such as switches.</p>
                         </div>
-                    </div>
                 </div>
-            </div>
+
         </div>
         <div class="about">
             <div class="container">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -200,9 +200,11 @@
                                 <div class="download-alt-content">
                                     <h3>Debian package</h3>
                                     <p>Takes care of all dependencies and is currently the most comprehensive. Requires Debian.</p>
-                                    <a href="/install-instructions/#debian" class="btn btn-primary">
-                                        <i class="fa fa-file-text-o"></i> Instructions
-                                    </a>
+                                    <div class="btn-group">
+                                        <a href="/install-instructions/#debian" class="btn btn-primary">
+                                            <i class="fa fa-file-text-o"></i> Instructions
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -39,7 +39,7 @@ body {
 
 /* Background image */
 .hero {
-    height:455px;
+    height:fit-content;
     background-size: 100%;
     background-size: cover;
     -webkit-background-size: cover;
@@ -66,10 +66,11 @@ body {
     height:100%;
     border-bottom:1px solid #1D2730;
     position:relative;
+    padding-top: 6.9em;
+    padding-bottom: 8.3em;
 }
 
 .hero-typo {
-    position:absolute;
     top:120px;
     left:0;
 }
@@ -79,7 +80,7 @@ body {
     position:absolute;
     bottom:0;
     left:0;
-    z-index:999;
+    z-index:2;
 }
 
 .quick-link-wrapper > ul {
@@ -103,6 +104,10 @@ body {
 .quick-link-wrapper > ul > li > a:hover {
     text-decoration:none;
     color:#EE8786;
+}
+
+.hero .container {
+    display: block;
 }
 
 /* Modifications on hero text */

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -233,6 +233,7 @@ body {
     text-align:center;
     padding:15px;
     padding-bottom:30px;
+    height: fit-content;
 }
 
 @media (min-width: 990px) {

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -240,8 +240,12 @@ body {
 }
 
 .download-alt-content p {
-    height:110px;
+    height:fit-content;
     display:block;
+}
+
+.download-alt-content .btn-group {
+    margin-top: 1.8em !important;
 }
 
 /* TOUR SECTION

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -106,8 +106,9 @@ body {
     color:#EE8786;
 }
 
+/* Overrider Bootstrap's default for container */
 .hero .container {
-    display: block;
+    display: block !important;
 }
 
 /* Modifications on hero text */

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -179,6 +179,22 @@ body {
     margin-top:20px;
 }
 
+#features {
+    margin-top: 4em;
+    margin-bottom: 4em;
+}
+
+.feature-icon {
+    margin-right: 2em;
+}
+
+@media (max-width: 990px){
+
+    .feature-icon {
+        margin-right: 0;
+    }
+}
+
 
 /* ABOUT SECTION
 ------------------------------------------------------------------ */

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -25,7 +25,7 @@ body {
 .menu .navbar-nav > li > a { color:white; }
 .menu .navbar-nav > li > a:hover { text-decoration:none; color:#1D2730; background:none; }
 .menu .navbar-nav > li {
-    font-size:18px;
+    font-size:1em;
     font-weight:400;
     padding-left:10px;
 }
@@ -93,7 +93,7 @@ body {
     display:inline-block;
     padding:10px;
     margin-right:30px;
-    font-size:23px;
+    font-size:1.28em;
 }
 
 .quick-link-wrapper > ul > li > a {
@@ -109,11 +109,11 @@ body {
 @media (max-width: 1200px) and (min-width: 990px) {
 
     .lead {
-        font-size:64px !important;
+        font-size:3.56em !important;
     }
 
     .sub {
-        font-size:23px !important;
+        font-size:1.28em !important;
     }
 }
 
@@ -124,11 +124,11 @@ body {
     }
 
     .lead {
-        font-size:70px !important;
+        font-size:3.89em !important;
     }
 
     .sub {
-        font-size:20px !important;
+        font-size:1.111em !important;
     }
 }
 
@@ -140,12 +140,12 @@ body {
 
     .lead {
         text-align:center;
-        font-size:58px !important;
+        font-size:3.222em !important;
     }
 
     .sub {
         text-align: center;
-        font-size:19px !important;
+        font-size:1.05556em !important;
 
     }
 
@@ -155,14 +155,14 @@ body {
 }
 
 .lead {
-    font-size:78px;
+    font-size:4.3333em;
     font-weight:300;
 
 }
 
 .sub {
     font-weight:300;
-    font-size:27px;
+    font-size:1.5em;
 
 }
 
@@ -192,7 +192,7 @@ body {
 .screenshots-caption {
     margin-top:10px;
     text-align:center;
-    font-size:16px;
+    font-size:0.88889em;
 }
 
 /* Carousel overrides */
@@ -267,12 +267,12 @@ section#users {
 
 #who .title {
     font-weight:600;
-    font-size:25px;
+    font-size:1.38889em;
 }
 
 #who .location {
     font-weight:400;
-    font-size:14px;
+    font-size:0.7778em;
     margin-bottom:10px;
 }
 
@@ -317,7 +317,7 @@ section#releases li {
 ------------------------------------------------------------------ */
 
 section#install-instructions {
-    font-size:14px;
+    font-size:0.7778em;
     font-weight:400;
 }
 
@@ -325,7 +325,7 @@ section#install-instructions {
 ------------------------------------------------------------------ */
 
 section#blog {
-    font-size:16px;
+    font-size:0.88889em;
 }
 
 article.blogpost header h1 {
@@ -362,7 +362,7 @@ footer#footer img {
 
 footer#footer h2 {
     font-weight:300;
-    font-size:34px;
+    font-size:1.88889em;
 }
 
 footer#footer i {
@@ -376,7 +376,7 @@ footer#footer .channels {
 
 footer#footer .author {
     margin-bottom:20px;
-    font-size:16px;
+    font-size:0.88889em;
 }
 
 footer#footer .page-header {
@@ -388,7 +388,7 @@ footer#footer .powered-by img {
 }
 
 footer#footer .photo-by {
-    font-size:14px;
+    font-size:0.7778em;
 }
 
 
@@ -398,7 +398,7 @@ footer#footer .photo-by {
 
 /* Heading for sections */
 .super-heading {
-    font-size:50px;
+    font-size:2.7778em;
 }
 
 .content {


### PR DESCRIPTION
Following WCAG requirements are satisfied:

- WCAG 2.0 - 1.4.4
- WCAG 2.1 - 1.4.10

In other words:

- On up to 200% text-only zoom:
    - All text is enlarged
    - No elements disappear
    - No overlaps
    - All buttons and links work
- On up to 400% zoom with at least 1280px screen width:
    - All buttons and links work
    - All functionality is same as before, and there is no need to scroll horizontally

Crome extension used for testing - _Zoom Text Only_. Text-only zoom is available in Firefox without extensions.