### PR TITLE
Add alphabetical sitemap

### DIFF
--- a/themes/navsite/layouts/partials/footer.html
+++ b/themes/navsite/layouts/partials/footer.html
@@ -55,6 +55,7 @@
         </div>
         <div class="row">
             <div class="col-md-6">
+            <div class="col-md-12">
                 <p class="photo-by">Original cover photo by <a href="http://www.flickr.com/photos/jneilson23/">Jeff Nielson</a>.
                     License <a href="http://creativecommons.org/licenses/by/2.0/">CCA2.0G</a>.
                 </p>

--- a/themes/navsite/layouts/partials/footer.html
+++ b/themes/navsite/layouts/partials/footer.html
@@ -39,22 +39,34 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-md-8">
+            <div class="col-md-6">
                 <div class="page-header">
                     <h2>Powered by</h2>
                 </div>
+                <div class="row bottom-space powered-by">
+                    <div class="col-md-12">
+                        <a href="http://python.org"><img src="/image/logos/32-powered-by-python.png" alt="[Python logo]" /></a>
+                        <a href="http://djangoproject.com"><img src="/image/logos/32-powered-by-django.png" alt="[Django logo]" /></a>
+                        <a href="http://postgresql.org"><img src="/image/logos/32-powered-by-postgresql.png" alt="[PostgreSQL logo]" /></a>
+                        <a href="http://jetbrains.com/pycharm/"><img src="/image/logos/32-powered-by-pycharm.png" alt="[PyCharm logo]" /></a>
+                    </div>
+                </div>
             </div>
-        </div>
-        <div class="row bottom-space powered-by">
-            <div class="col-md-8">
-                <a href="http://python.org"><img src="/image/logos/32-powered-by-python.png" alt="[Python logo]" /></a>
-                <a href="http://djangoproject.com"><img src="/image/logos/32-powered-by-django.png" alt="[Django logo]" /></a>
-                <a href="http://postgresql.org"><img src="/image/logos/32-powered-by-postgresql.png" alt="[PostgreSQL logo]" /></a>
-                <a href="http://jetbrains.com/pycharm/"><img src="/image/logos/32-powered-by-pycharm.png" alt="[PyCharm logo]" /></a>
-            </div>
-        </div>
-        <div class="row">
+
             <div class="col-md-6">
+                <div class="page-header">
+                    <h2>Alphabetical Site Map</h2>
+                </div>
+                <ul class="nav nav-pills sitemap">
+                    <li><a href="/blog/">Blog</a></li>
+                    <li><a href="https://nav.readthedocs.io/">Documentation</a></li>
+                    <li><a class="jump-link" data-section="download" href="/#download">Download</a></li>
+                    <li><a href="/">Home</a></li>
+                    <li><a class="jump-link" data-section="tour" href="/#tour">Tour</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="row text-center">
             <div class="col-md-12">
                 <p class="photo-by">Original cover photo by <a href="http://www.flickr.com/photos/jneilson23/">Jeff Nielson</a>.
                     License <a href="http://creativecommons.org/licenses/by/2.0/">CCA2.0G</a>.

--- a/themes/navsite/layouts/partials/footer.html
+++ b/themes/navsite/layouts/partials/footer.html
@@ -43,14 +43,12 @@
                 <div class="page-header">
                     <h2>Powered by</h2>
                 </div>
-                <div class="row bottom-space powered-by">
-                    <div class="col-md-12">
-                        <a href="http://python.org"><img src="/image/logos/32-powered-by-python.png" alt="[Python logo]" /></a>
-                        <a href="http://djangoproject.com"><img src="/image/logos/32-powered-by-django.png" alt="[Django logo]" /></a>
-                        <a href="http://postgresql.org"><img src="/image/logos/32-powered-by-postgresql.png" alt="[PostgreSQL logo]" /></a>
-                        <a href="http://jetbrains.com/pycharm/"><img src="/image/logos/32-powered-by-pycharm.png" alt="[PyCharm logo]" /></a>
-                    </div>
-                </div>
+                <ul class="nav nav-pills powered-by">
+                    <li><a href="http://python.org"><img src="/image/logos/32-powered-by-python.png" alt="[Python logo]" /></a></li>
+                    <li><a href="http://djangoproject.com"><img src="/image/logos/32-powered-by-django.png" alt="[Django logo]" /></a></li>
+                    <li><a href="http://postgresql.org"><img src="/image/logos/32-powered-by-postgresql.png" alt="[PostgreSQL logo]" /></a></li>
+                    <li><a href="http://jetbrains.com/pycharm/"><img src="/image/logos/32-powered-by-pycharm.png" alt="[PyCharm logo]" /></a></li>
+                </ul>
             </div>
 
             <div class="col-md-6">

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -493,6 +493,7 @@ footer#footer .page-header {
 
 footer#footer .photo-by {
     font-size:0.7778em;
+    margin-top: 1em;
 }
 
 .author a {

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -530,7 +530,10 @@ footer#footer .photo-by {
 .author a:focus-within,
 .powered-by a:focus-visible,
 .powered-by a:focus,
-.powered-by a:focus-within {
+.powered-by a:focus-within,
+.sitemap a:focus-visible,
+.sitemap a:focus,
+.sitemap a:focus-within {
     box-shadow: 0 0 2px 1px #2A6293, inset 0 0 0 1px #2A6293;
     -webkit-border-radius: 5px;
 }
@@ -580,9 +583,9 @@ a {
 }
 
 /* All links except the ones mentioned in :not() */
-a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a, .author a, .powered-by a):focus,
-a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a, .author a, .powered-by a):focus-within,
-a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a, .author a, .powered-by a):focus-visible {
+a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a, .author a, .powered-by a, .sitemap a):focus,
+a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a, .author a, .powered-by a, .sitemap a):focus-within,
+a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a, .author a, .powered-by a, .sitemap a):focus-visible {
     padding: 0 0.3em;
     box-shadow: 0 0 2px 1px #2A6293, inset 0 0 0 1px #2A6293;
     -webkit-border-radius: 5px;

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -508,6 +508,7 @@ footer#footer .photo-by {
 .powered-by > div {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
 }
 
 .powered-by a {

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -519,7 +519,8 @@ footer#footer .photo-by {
 }
 
 .author a:hover,
-.powered-by a:hover {
+.powered-by a:hover,
+.sitemap a:hover {
     box-shadow: 0 0 2px 0.05em #2A6293, inset 0 0 0 0.01em #2A6293;
     -webkit-border-radius: 5px;
 }

--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -491,10 +491,6 @@ footer#footer .page-header {
     margin-bottom:30px;
 }
 
-footer#footer .powered-by img {
-    margin-right:20px;
-}
-
 footer#footer .photo-by {
     font-size:0.7778em;
 }
@@ -511,11 +507,8 @@ footer#footer .photo-by {
     flex-wrap: wrap;
 }
 
-.powered-by a {
-    width: fit-content;
-    height: 35px;
-    margin: 0 0.1em;
-    padding: 0 0.1em;
+.powered-by img {
+    margin: 0 !important;
 }
 
 .author a:hover,


### PR DESCRIPTION
Following requirements are satisfied:

- WCAG 2.0 - 2.4.5

In other words:

- There at least 2 ways to navigate/access the pages on the website. In our case: nav header and an alphabetical sitemap.

Alternatives to the alphabetical site map that were considered:

- Embedded google search on the page (see example on the UiB's website https://www.uib.no/google-s%C3%B8k): dismissed because more tedious and of little relevance for such a small website.
- Non-alphabetical site map: dismissed because is would be a copy of the header.
- Links between webpages: dismissed because I dont really comprehend how it is supposed to work.