### PR TITLE
Fix blogpost headers in accordance with WCAG

### DIFF
--- a/layouts/install-instructions/list.html
+++ b/layouts/install-instructions/list.html
@@ -5,7 +5,7 @@
     {{ range .Pages }}
     <div class="row">
       <div class="col-md-12">
-	<h1 id="{{ .File.TranslationBaseName }}" class="page-header">{{ .Title }}</h1>
+	<h2 id="{{ .File.TranslationBaseName }}" class="page-header h1">{{ .Title }}</h2>
 	{{ .Content }}
       </div>
     </div>

--- a/themes/navsite/layouts/partials/script.html
+++ b/themes/navsite/layouts/partials/script.html
@@ -45,4 +45,47 @@
           });
         }).resize();
     });
+
+    $(function convertAllBlogpostsH1ToH2() {
+        const h1Headers = document.querySelectorAll('header h1');
+        console.log('h1 headers', h1Headers);
+
+        for (let i = 0; i < h1Headers.length; i++) {
+            // Add Bootstrap's h1 styling
+            h1Headers[i].classList.add('h1');
+
+            h1Headers[i].outerHTML = h1Headers[i].outerHTML.replace('h1', 'h2');
+        }
+    });
+
+
+    $(function convertAllBlogpostHeadersToH3() {
+        const h2BlogpostHeaders = document.querySelectorAll('.blogpost > h2');
+        console.log('h2 headers', h2BlogpostHeaders);
+        for (let i = 0; i < h2BlogpostHeaders.length; i++) {
+            // Add Bootstrap's h2 styling
+            h2BlogpostHeaders[i].classList.add('h2');
+
+            h2BlogpostHeaders[i].outerHTML = h2BlogpostHeaders[i].outerHTML.replace('h2', 'h3');
+        }
+
+        const h4BlogpostHeaders = document.querySelectorAll('.blogpost > h4');
+        console.log('h4 headers', h4BlogpostHeaders);
+        for (let i = 0; i < h4BlogpostHeaders.length; i++) {
+            // Add Bootstrap's h4 styling
+            h4BlogpostHeaders[i].classList.add('h4');
+
+            h4BlogpostHeaders[i].outerHTML = h4BlogpostHeaders[i].outerHTML.replace('h4', 'h3');
+        }
+    });
+
+    $(function convertSingleBlogpostH1ToH2() {
+        const h1Header = document.querySelector('header h1');
+
+        // Add Bootstrap's h1 styling
+        h1Header.classList.add('h1');
+
+        h1Header.outerHTML = h1Header.outerHTML.replace('h1', 'h2');
+    });
+
 </script>


### PR DESCRIPTION
Changes made:

- All blogpost title headers are h2, but styled as h1
- All other blogpost headers are converted to h3, but styled same as original was
- Install instructions h1 is changed to h2

Closes #13 