### PR TITLE
Render blog post headings starting at h2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,9 +6,6 @@ theme = "navsite"
 [permalinks]
   blog = '/blog/:year/:month/:title/'
 
-[markup.goldmark.parser]
-  autoHeadingID = false
-
 [markup.goldmark.renderer]
   unsafe = true
 

--- a/layouts/blog/_markup/render-heading.html
+++ b/layouts/blog/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level | add 1 }}>{{ .Text }}</h{{ .Level | add 1}}>

--- a/layouts/partials/full-blog-body.html
+++ b/layouts/partials/full-blog-body.html
@@ -1,7 +1,7 @@
     <div class="row">
       <article class="col-md-12 blogpost">
         <header>
-          <a href="{{ .Permalink }}"><h1 id="{{ .File.TranslationBaseName }}">{{ .Title }}</h1></a>
+          <a href="{{ .Permalink }}"><h2 id="{{ .File.TranslationBaseName }}">{{ .Title }}</h2></a>
           <aside class="pubdate">
             <p>Posted on {{ .PublishDate.Format "Jan 2, 2006" }}</p>
           </aside>


### PR DESCRIPTION
This defaults blog post titles to h2, and hooks into markdown header rendering to increase the level by 1 for all headings rendered in the blog section.

This is an alternative to #24 