### PR TITLE
Fix heading for instructions

### DIFF
--- a/layouts/install-instructions/list.html
+++ b/layouts/install-instructions/list.html
@@ -5,7 +5,7 @@
     {{ range .Pages }}
     <div class="row">
       <div class="col-md-12">
-	<h1 id="{{ .File.TranslationBaseName }}" class="page-header">{{ .Title }}</h1>
+	<h2 id="{{ .File.TranslationBaseName }}" class="page-header">{{ .Title }}</h2>
 	{{ .Content }}
       </div>
     </div>


### PR DESCRIPTION
Was fixed in #24, but overlooked in #26.

Changed heading to h2 since we now have a hidden h1 header om all pages.
Even though multiple h1s are allowed by Norwegian law, it is still a bad practice since it is confusing for users who use screen readers.