### PR TITLE
Clean up blog post tags

### DIFF
--- a/content/blog/gaps-in-graphite-graphs.md
+++ b/content/blog/gaps-in-graphite-graphs.md
@@ -4,7 +4,6 @@ date: 2015-05-05T07:24:00.000+02:00
 draft: false
 url: /blog/2015/05/gaps-in-graphite-graphs/
 tags: 
-- regular
 - graphite
 ---
 

--- a/content/blog/nav-40.md
+++ b/content/blog/nav-40.md
@@ -4,7 +4,6 @@ date: 2014-04-08T06:18:00.000+02:00
 draft: false
 url: /blog/2014/04/nav-40/
 tags: 
-- regular
 ---
 
 <img alt="Cake with NAV logo" src="http://55.media.tumblr.com/935015da00fd090b8c984b8297d9691d/tumblr_inline_n3plreofEe1swzy6x.jpg" class="pull-right" title="NAV cake"/>

--- a/content/blog/nav-422-released.md
+++ b/content/blog/nav-422-released.md
@@ -4,6 +4,7 @@ date: 2015-01-09T02:24:00.000+01:00
 draft: false
 url: /blog/2015/01/nav-422-released/
 tags: 
+- release
 - bugfix
 - 4.2
 ---

--- a/content/blog/nav-422-released.md
+++ b/content/blog/nav-422-released.md
@@ -5,8 +5,6 @@ draft: false
 url: /blog/2015/01/nav-422-released/
 tags: 
 - bugfix
-- nav
-- regular
 - 4.2
 ---
 

--- a/content/blog/nav-423-released.md
+++ b/content/blog/nav-423-released.md
@@ -4,6 +4,7 @@ date: 2015-02-13T07:52:00.000+01:00
 draft: false
 url: /blog/2015/02/nav-423-released/
 tags: 
+- release
 - bugfix
 - 4.2
 ---

--- a/content/blog/nav-423-released.md
+++ b/content/blog/nav-423-released.md
@@ -5,8 +5,6 @@ draft: false
 url: /blog/2015/02/nav-423-released/
 tags: 
 - bugfix
-- nav
-- regular
 - 4.2
 ---
 

--- a/content/blog/nav-425-released.md
+++ b/content/blog/nav-425-released.md
@@ -5,8 +5,6 @@ draft: false
 url: /blog/2015/03/nav-425-released/
 tags: 
 - bugfix
-- nav
-- regular
 - 4.2
 ---
 

--- a/content/blog/nav-425-released.md
+++ b/content/blog/nav-425-released.md
@@ -4,6 +4,7 @@ date: 2015-03-23T02:19:00.000+01:00
 draft: false
 url: /blog/2015/03/nav-425-released/
 tags: 
+- release
 - bugfix
 - 4.2
 ---

--- a/content/blog/nav-426-released.md
+++ b/content/blog/nav-426-released.md
@@ -5,8 +5,6 @@ draft: false
 url: /blog/2015/04/nav-426-released/
 tags: 
 - bugfix
-- nav
-- regular
 - 4.2
 ---
 

--- a/content/blog/nav-426-released.md
+++ b/content/blog/nav-426-released.md
@@ -4,6 +4,7 @@ date: 2015-04-23T06:18:00.000+02:00
 draft: false
 url: /blog/2015/04/nav-426-released/
 tags: 
+- release
 - bugfix
 - 4.2
 ---

--- a/content/blog/nav-430-release-candidate-1.md
+++ b/content/blog/nav-430-release-candidate-1.md
@@ -4,6 +4,7 @@ date: 2015-05-21T08:59:00.000+02:00
 draft: false
 url: /blog/2015/05/nav-430-release-candidate-1/
 tags: 
+- release
 - rc
 ---
 

--- a/content/blog/nav-430-release-candidate-1.md
+++ b/content/blog/nav-430-release-candidate-1.md
@@ -4,8 +4,6 @@ date: 2015-05-21T08:59:00.000+02:00
 draft: false
 url: /blog/2015/05/nav-430-release-candidate-1/
 tags: 
-- nav
-- regular
 - rc
 ---
 

--- a/content/blog/nav-430-released.md
+++ b/content/blog/nav-430-released.md
@@ -4,6 +4,7 @@ date: 2015-06-12T01:23:00.000+02:00
 draft: false
 url: /blog/2015/06/nav-430-released/
 tags: 
+- release
 - 4.3
 ---
 

--- a/content/blog/nav-430-released.md
+++ b/content/blog/nav-430-released.md
@@ -5,8 +5,6 @@ draft: false
 url: /blog/2015/06/nav-430-released/
 tags: 
 - 4.3
-- nav
-- regular
 ---
 
 The initial 4.3 series release of NAV is now out, with only minor changes and some bugfixes since the release candidate. A big thanks to those who helped test the release candidate!

--- a/content/blog/nav-431-released.md
+++ b/content/blog/nav-431-released.md
@@ -4,6 +4,7 @@ date: 2015-08-20T06:50:00.000+02:00
 draft: false
 url: /blog/2015/08/nav-431-released/
 tags: 
+- release
 - bugfix
 - 4.3
 - 4.3.1

--- a/content/blog/nav-431-released.md
+++ b/content/blog/nav-431-released.md
@@ -6,8 +6,6 @@ url: /blog/2015/08/nav-431-released/
 tags: 
 - bugfix
 - 4.3
-- nav
-- regular
 - 4.3.1
 ---
 

--- a/content/blog/nav-432-released.md
+++ b/content/blog/nav-432-released.md
@@ -4,6 +4,7 @@ date: 2015-11-19T05:52:00.000+01:00
 draft: false
 url: /blog/2015/11/nav-432-released/
 tags: 
+- release
 - bugfix
 - 4.3
 ---

--- a/content/blog/nav-432-released.md
+++ b/content/blog/nav-432-released.md
@@ -6,8 +6,6 @@ url: /blog/2015/11/nav-432-released/
 tags: 
 - bugfix
 - 4.3
-- nav
-- regular
 ---
 
 The second maintenance release of the NAV 4.3 series is now out.

--- a/content/blog/nav-433-released.md
+++ b/content/blog/nav-433-released.md
@@ -4,6 +4,7 @@ date: 2016-01-15T00:38:00.000+01:00
 draft: false
 url: /blog/2016/01/nav-433-released/
 tags: 
+- release
 - bugfix
 - 4.3.3
 - 4.3

--- a/content/blog/nav-433-released.md
+++ b/content/blog/nav-433-released.md
@@ -7,8 +7,6 @@ tags:
 - bugfix
 - 4.3.3
 - 4.3
-- nav
-- regular
 ---
 
 _This is posted a while after the actual release_

--- a/content/blog/nav-440-released.md
+++ b/content/blog/nav-440-released.md
@@ -6,8 +6,6 @@ url: /blog/2016/01/nav-440-released/
 tags: 
 - release
 - 4.4
-- nav
-- regular
 - 4.4.0
 ---
 

--- a/content/blog/nav-441-released.md
+++ b/content/blog/nav-441-released.md
@@ -7,8 +7,6 @@ tags:
 - bugfix
 - 4.4.1
 - 4.4
-- nav
-- regular
 ---
 
 The first maintenance release of the NAV 4.4 series is now out.

--- a/content/blog/nav-441-released.md
+++ b/content/blog/nav-441-released.md
@@ -4,6 +4,7 @@ date: 2016-01-21T06:46:00.000+01:00
 draft: false
 url: /blog/2016/01/nav-441-released/
 tags: 
+- release
 - bugfix
 - 4.4.1
 - 4.4

--- a/content/blog/nav-442-released.md
+++ b/content/blog/nav-442-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.4.2 released'
 date: 2016-02-04T15:53:00.000+01:00
 draft: false
 url: /blog/2016/02/nav-442-released/
+tags:
+- release
 ---
 
 The second maintenance release of the NAV 4.4 series is now out.

--- a/content/blog/nav-443-released.md
+++ b/content/blog/nav-443-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.4.3 released'
 date: 2016-04-05T13:17:00.000+02:00
 draft: false
 url: /blog/2016/04/nav-443-released/
+tags:
+- release
 ---
 
 The third maintenance release of the NAV 4.4 series was released 31.03.

--- a/content/blog/nav-444-released.md
+++ b/content/blog/nav-444-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.4.4 released'
 date: 2016-06-09T13:01:00.000+02:00
 draft: false
 url: /blog/2016/06/nav-444-released/
+tags:
+- release
 ---
 
 The fourth maintenance release of the NAV 4.4 series was released 02.06.

--- a/content/blog/nav-450-released.md
+++ b/content/blog/nav-450-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.5.0 released'
 date: 2016-06-09T13:05:00.000+02:00
 draft: false
 url: /blog/2016/06/nav-450-released/
+tags:
+- release
 ---
 
 The initial 4.5 series release of NAV is now out.

--- a/content/blog/nav-451-released.md
+++ b/content/blog/nav-451-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.5.1 released'
 date: 2016-06-16T15:03:00.000+02:00
 draft: false
 url: /blog/2016/06/nav-451-released/
+tags:
+- release
 ---
 
 The first maintenance release of the NAV 4.5 series is now out.

--- a/content/blog/nav-452-released.md
+++ b/content/blog/nav-452-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.5.2 released'
 date: 2016-06-30T11:41:00.000+02:00
 draft: false
 url: /blog/2016/06/nav-452-released/
+tags:
+- release
 ---
 
 The second maintenance release of the NAV 4.5 series is now out.

--- a/content/blog/nav-453-released.md
+++ b/content/blog/nav-453-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.5.3 released'
 date: 2016-09-05T08:41:00.000+02:00
 draft: false
 url: /blog/2016/09/the-third-maintenance-release-of-nav-4/
+tags:
+- release
 ---
 
 The third maintenance release of the NAV 4.5 series is now out.

--- a/content/blog/nav-460-released.md
+++ b/content/blog/nav-460-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.6.0 released'
 date: 2016-12-01T15:27:00.001+01:00
 draft: false
 url: /blog/2016/12/nav-460-released/
+tags:
+- release
 ---
 
 The initial 4.6 series release of NAV is now out!

--- a/content/blog/nav-461-released.md
+++ b/content/blog/nav-461-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.6.1 released'
 date: 2017-01-26T14:06:00.000+01:00
 draft: false
 url: /blog/2017/01/nav-461-released/
+tags:
+- release
 ---
 
 The first maintenance release of the 4.6 series release of NAV is now out!

--- a/content/blog/nav-462-released.md
+++ b/content/blog/nav-462-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.6.2 released'
 date: 2017-03-16T12:07:00.000+01:00
 draft: false
 url: /blog/2017/03/nav-462-released/
+tags:
+- release
 ---
 
 The second maintenance release of the 4.6 series of NAV is now out!

--- a/content/blog/nav-470-released.md
+++ b/content/blog/nav-470-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.7.0 released'
 date: 2017-06-09T16:13:00.001+02:00
 draft: false
 url: /blog/2017/06/nav-470-released/
+tags:
+- release
 ---
 
 The initial 4.7 series release of NAV is now out!

--- a/content/blog/nav-471-released.md
+++ b/content/blog/nav-471-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.7.1 released'
 date: 2017-06-09T16:14:00.002+02:00
 draft: false
 url: /blog/2017/06/nav-471-released/
+tags:
+- release
 ---
 
 We apologize for the issues with yesterday's NAV release, which, apparently, our test suite was unable to detect.

--- a/content/blog/nav-472-released.md
+++ b/content/blog/nav-472-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.7.2 released'
 date: 2017-09-29T08:20:00.000+02:00
 draft: false
 url: /blog/2017/09/nav-472-released/
+tags:
+- release
 ---
 
 The second maintenance release of the 4.7 series of NAV is now out!

--- a/content/blog/nav-473-released.md
+++ b/content/blog/nav-473-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.7.3 released'
 date: 2017-11-13T09:15:00.000+01:00
 draft: false
 url: /blog/2017/11/nav-473-released/
+tags:
+- release
 ---
 
 The third maintenance release of the 4.7 series of NAV is now out!

--- a/content/blog/nav-480-released.md
+++ b/content/blog/nav-480-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.8.0 released'
 date: 2017-11-24T08:19:00.000+01:00
 draft: false
 url: /blog/2017/11/the-initial-feature-release-of-4/
+tags:
+- release
 ---
 
 The initial feature release of the 4.8 series of NAV is now out!

--- a/content/blog/nav-481-released.md
+++ b/content/blog/nav-481-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.8.1 released'
 date: 2017-11-30T15:07:00.000+01:00
 draft: false
 url: /blog/2017/11/nav-481-released/
+tags:
+- release
 ---
 
 The first maintenance release of the 4.8 series of NAV is now out!

--- a/content/blog/nav-482-released.md
+++ b/content/blog/nav-482-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.8.2 released'
 date: 2017-12-07T10:17:00.000+01:00
 draft: false
 url: /blog/2017/12/nav-482-released/
+tags:
+- release
 ---
 
 The second maintenance release of the 4.8 series of NAV is now out!

--- a/content/blog/nav-483-released.md
+++ b/content/blog/nav-483-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.8.3 released'
 date: 2018-01-12T08:28:00.000+01:00
 draft: false
 url: /blog/2018/01/nav-483-released/
+tags:
+- release
 ---
 
 The third maintenance release of the 4.8 series of NAV is now out!

--- a/content/blog/nav-484-released.md
+++ b/content/blog/nav-484-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.8.4 released'
 date: 2018-04-05T16:18:00.000+02:00
 draft: false
 url: /blog/2018/04/nav-484-released/
+tags:
+- release
 ---
 
 The fourth maintenance release of the 4.8 series of NAV is now out!

--- a/content/blog/nav-485-released.md
+++ b/content/blog/nav-485-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.8.5 released'
 date: 2018-06-22T08:06:00.000+02:00
 draft: false
 url: /blog/2018/06/nav-485-released/
+tags:
+- release
 ---
 
 The fifth maintenance release of the 4.8 series of NAV is now out!

--- a/content/blog/nav-49-released.md
+++ b/content/blog/nav-49-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9 released'
 date: 2019-02-14T12:02:00.000+01:00
 draft: false
 url: /blog/2019/02/nav-49-released/
+tags:
+- release
 ---
 
 During a two-week whirlwind, three releases have been made in the new 4.9 series of NAV.

--- a/content/blog/nav-493-released.md
+++ b/content/blog/nav-493-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9.3 released'
 date: 2019-02-28T13:00:00.000+01:00
 draft: false
 url: /blog/2019/02/nav-493-released/
+tags:
+- release
 ---
 
 The third maintenance release of the 4.9 series of NAV is now out!

--- a/content/blog/nav-494-released.md
+++ b/content/blog/nav-494-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9.4 released'
 date: 2019-03-28T08:53:00.000+01:00
 draft: false
 url: /blog/2019/03/nav-494-released/
+tags:
+- release
 ---
 
 The fourth maintenance release of the 4.9 series of NAV is now out!

--- a/content/blog/nav-495-released.md
+++ b/content/blog/nav-495-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9.5 released'
 date: 2019-05-02T11:55:00.001+02:00
 draft: false
 url: /blog/2019/05/nav-495-released/
+tags:
+- release
 ---
 
 The fifth maintenance release of the 4.9 series of NAV is now out!

--- a/content/blog/nav-496-released.md
+++ b/content/blog/nav-496-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9.6 released'
 date: 2019-05-23T12:45:00.000+02:00
 draft: false
 url: /blog/2019/05/nav-496-released/
+tags:
+- release
 ---
 
 The sixth maintenance release of the 4.9 series of NAV is now out!

--- a/content/blog/nav-497-released.md
+++ b/content/blog/nav-497-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9.7 released'
 date: 2019-06-07T10:42:00.000+02:00
 draft: false
 url: /blog/2019/06/nav-497-released/
+tags:
+- release
 ---
 
 The seventh maintenance release of the 4.9 series of NAV is now out!

--- a/content/blog/nav-498-released.md
+++ b/content/blog/nav-498-released.md
@@ -3,6 +3,8 @@ title: 'NAV 4.9.8 released'
 date: 2019-08-22T14:54:00.000+02:00
 draft: false
 url: /blog/2019/08/nav-498-released/
+tags:
+- release
 ---
 
 The eighth maintenance release of the 4.9 series of NAV is now out!

--- a/content/blog/nav-500-released.md
+++ b/content/blog/nav-500-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.0 released'
 date: 2019-11-07T12:26:00.000+01:00
 draft: false
 url: /blog/2019/11/nav-500-released/
+tags:
+- release
 ---
 
 The first feature release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-501-released.md
+++ b/content/blog/nav-501-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.1 released'
 date: 2019-12-05T11:19:00.000+01:00
 draft: false
 url: /blog/2019/12/nav-501-released/
+tags:
+- release
 ---
 
 The first maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-502-released.md
+++ b/content/blog/nav-502-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.2 released'
 date: 2019-12-13T13:32:00.001+01:00
 draft: false
 url: /blog/2019/12/nav-502-released/
+tags:
+- release
 ---
 
 The second maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-503-released.md
+++ b/content/blog/nav-503-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.3 released'
 date: 2019-12-19T13:50:00.002+01:00
 draft: false
 url: /blog/2019/12/nav-503-released/
+tags:
+- release
 ---
 
 The third maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-504-released.md
+++ b/content/blog/nav-504-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.4 released'
 date: 2020-01-16T11:14:00.000+01:00
 draft: false
 url: /blog/2020/01/nav-504-released/
+tags:
+- release
 ---
 
 The fourth maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-505-released.md
+++ b/content/blog/nav-505-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.5 released'
 date: 2020-03-13T16:09:00.000+01:00
 draft: false
 url: /blog/2020/03/nav-505-released/
+tags:
+- release
 ---
 
 It's Friday the 13th and a pandemic is upon us, so we thought: Why not release the fifth maintenance version of the 5.0 series of NAV!

--- a/content/blog/nav-506-released.md
+++ b/content/blog/nav-506-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.6 released'
 date: 2020-08-27T16:37:00.001+02:00
 draft: false
 url: /blog/2020/08/nav-506-released/
+tags:
+- release
 ---
 
 The sixth maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-507-released.md
+++ b/content/blog/nav-507-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.7 released'
 date: 2020-10-15T14:46:00.000+02:00
 draft: false
 url: /blog/2020/10/nav-507-released/
+tags:
+- release
 ---
 
 The seventh maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-508-released.md
+++ b/content/blog/nav-508-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.0.8 released'
 date: 2020-10-23T13:26:00.001+02:00
 draft: false
 url: /blog/2020/10/nav-508-released/
+tags:
+- release
 ---
 
 The eighth maintenance release of the 5.0 series of NAV is now out!

--- a/content/blog/nav-51-released.md
+++ b/content/blog/nav-51-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.1 released'
 date: 2020-11-26T15:48:00.000+01:00
 draft: false
 url: /blog/2020/11/nav-51-released/
+tags:
+- release
 ---
 
 The initial feature release of the 5.1 series of NAV is now out!

--- a/content/blog/nav-511-released.md
+++ b/content/blog/nav-511-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.1.1 released'
 date: 2020-12-07T12:55:00.002+01:00
 draft: false
 url: /blog/2020/12/nav-511-released/
+tags:
+- release
 ---
 
 The first maintenance release of the 5.1 series of NAV is now out!

--- a/content/blog/nav-512-released.md
+++ b/content/blog/nav-512-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.1.2 released'
 date: 2021-01-15T10:45:00.003+01:00
 draft: false
 url: /blog/2021/01/nav-512-released/
+tags:
+- release
 ---
 
 The second maintenance release of the 5.1 series of NAV is now out!

--- a/content/blog/nav-513-released.md
+++ b/content/blog/nav-513-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.1.3 released'
 date: 2021-04-09T09:51:00.000+02:00
 draft: false
 url: /blog/2021/04/nav-513-released/
+tags:
+- release
 ---
 
 The third maintenance release of the 5.1 series of NAV is now out!

--- a/content/blog/nav-514-released.md
+++ b/content/blog/nav-514-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.1.4 released'
 date: 2021-06-24T11:51:00.001+02:00
 draft: false
 url: /blog/2021/06/nav-514-released/
+tags:
+- release
 ---
 
 The fourth maintenance release of the 5.1 series of NAV is now out!

--- a/content/blog/nav-520-released.md
+++ b/content/blog/nav-520-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.2.0 released'
 date: 2021-09-16T11:09:00.000+02:00
 draft: false
 url: /blog/2021/09/nav-520-released/
+tags:
+- release
 ---
 
 The initial feature release of the 5.2 series of NAV is now out!

--- a/content/blog/nav-521-released.md
+++ b/content/blog/nav-521-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.2.1 released'
 date: 2021-09-23T14:13:00.002+02:00
 draft: false
 url: /blog/2021/09/nav-521-released/
+tags:
+- release
 ---
 
 The first maintenance release of the 5.2 series of NAV is now out!

--- a/content/blog/nav-530-released.md
+++ b/content/blog/nav-530-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.3.0 released'
 date: 2022-02-22T18:49:00.001+01:00
 draft: false
 url: /blog/2022/02/nav-530-released/
+tags:
+- release
 ---
 
 The initial maintenance release of the 5.3 series of NAV is now out!

--- a/content/blog/nav-540-released.md
+++ b/content/blog/nav-540-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.4.0 released'
 date: 2022-05-19T22:48:00.000+02:00
 draft: false
 url: /blog/2022/05/nav-540-released/
+tags:
+- release
 ---
 
 The initial feature release of the 5.4 series of NAV is now out!

--- a/content/blog/nav-550-released.md
+++ b/content/blog/nav-550-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.5.0 released'
 date: 2022-11-04T13:06:00.000+02:00
 draft: false
 url: /blog/2022/11/nav-550-released/
+tags:
+- release
 ---
 
 The initial feature release of the 5.5 series of NAV is now out!

--- a/content/blog/nav-551-released.md
+++ b/content/blog/nav-551-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.5.1 released'
 date: 2022-11-09T09:24:00.000+02:00
 draft: false
 url: /blog/2022/11/nav-551-released/
+tags:
+- release
 ---
 
 The first maintenance release of the 5.5 series of NAV is now out!

--- a/content/blog/nav-552-released.md
+++ b/content/blog/nav-552-released.md
@@ -3,6 +3,8 @@ title: 'NAV 5.5.2 released'
 date: 2022-11-10T10:23:00.000+02:00
 draft: false
 url: /blog/2022/11/nav-552-released/
+tags:
+- release
 ---
 
 The second maintenance release of the 5.5 series of NAV is now out,

--- a/content/blog/new-beta-release.md
+++ b/content/blog/new-beta-release.md
@@ -4,7 +4,6 @@ date: 2014-02-12T01:17:00.000+01:00
 draft: false
 url: /blog/2014/02/new-beta-release/
 tags: 
-- regular
 ---
 
 A new beta of NAV 4.0 is released. In addition to the new logo, you will also find interface improvements all over.

--- a/content/blog/new-beta-release.md
+++ b/content/blog/new-beta-release.md
@@ -4,6 +4,7 @@ date: 2014-02-12T01:17:00.000+01:00
 draft: false
 url: /blog/2014/02/new-beta-release/
 tags: 
+- release
 ---
 
 A new beta of NAV 4.0 is released. In addition to the new logo, you will also find interface improvements all over.

--- a/content/blog/new-nav-logo.md
+++ b/content/blog/new-nav-logo.md
@@ -4,7 +4,6 @@ date: 2014-01-27T05:18:00.000+01:00
 draft: false
 url: /blog/2014/01/new-nav-logo/
 tags: 
-- regular
 ---
 
 ![NAV logo](/image/blog/tumblr_inline_n0274rbeo81sww2qo.png)

--- a/content/blog/post-40-experiences-and-41-plans.md
+++ b/content/blog/post-40-experiences-and-41-plans.md
@@ -4,7 +4,6 @@ date: 2014-05-12T10:18:00.000+02:00
 draft: false
 url: /blog/2014/05/post-40-experiences-and-41-plans/
 tags: 
-- regular
 ---
 
 NAV 4.0 has now been widely deployed, and people are enjoying the fresh layout, improved interface and (not really enjoying) new bugs. The feedback has been very good, but some issues have been raised.

--- a/content/blog/statistics.md
+++ b/content/blog/statistics.md
@@ -4,7 +4,6 @@ date: 2014-02-26T03:53:00.000+01:00
 draft: false
 url: /blog/2014/02/statistics/
 tags: 
-- regular
 ---
 
 One of the goals we had when we moved from Cricket to Graphite for statistics was to integrate the graphs more with NAV, instead of having to navigate to another webpage to get the information you wanted.

--- a/content/blog/the-nav-api.md
+++ b/content/blog/the-nav-api.md
@@ -4,8 +4,6 @@ date: 2015-05-21T09:03:00.000+02:00
 draft: false
 url: /blog/2015/05/the-nav-api/
 tags: 
-- nav
-- regular
 - api
 ---
 

--- a/content/blog/the-road-to-40.md
+++ b/content/blog/the-road-to-40.md
@@ -6,7 +6,6 @@ url: /blog/2014/01/the-road-to-40/
 tags: 
 - cricket
 - 4.0
-- regular
 - rrdtool
 - graphite
 - history101

--- a/content/blog/why-i-love-whisper.md
+++ b/content/blog/why-i-love-whisper.md
@@ -4,7 +4,6 @@ date: 2014-03-05T07:02:00.000+01:00
 draft: false
 url: /blog/2014/03/why-i-love-whisper/
 tags: 
-- regular
 ---
 
 We have just built a new, modern server room at UNINETT, with robust power distribution and cooling systems, and of course, we want to monitor the server room environment using NAV.


### PR DESCRIPTION
The tag usage has been very inconsistent throughout the years. This removes unnecessary tags and adds the release tag to all posts that are just release announcements.

However: There is no template to display tags as of yet. This should be added.