### PR TITLE
Change blog link to external blog

### DIFF
--- a/themes/navsite/layouts/partials/footer.html
+++ b/themes/navsite/layouts/partials/footer.html
@@ -56,7 +56,7 @@
                     <h2>Alphabetical Site Map</h2>
                 </div>
                 <ul class="nav nav-pills sitemap">
-                    <li><a href="/blog/">Blog</a></li>
+                    <li><a href="https://blog.nav.uninett.no/">Blog</a></li>
                     <li><a href="https://nav.readthedocs.io/">Documentation</a></li>
                     <li><a class="jump-link" data-section="download" href="/#download">Download</a></li>
                     <li><a href="/">Home</a></li>

--- a/themes/navsite/layouts/partials/header.html
+++ b/themes/navsite/layouts/partials/header.html
@@ -14,7 +14,7 @@
                 <ul class="nav navbar-nav">
                     <li><a class="jump-link" data-section="download" href="/#download">Download</a></li>
                     <li><a class="jump-link" data-section="tour" href="/#tour">Tour</a></li>
-                    <li><a href="/blog/">Blog</a></li>
+                    <li><a href="https://blog.nav.uninett.no/">Blog</a></li>
                     <li><a href="https://nav.readthedocs.io/">Documentation</a></li>
                 </ul>
         </div>


### PR DESCRIPTION
This is a temporary revert to how blog was linked previously.  Internal blog links are not yet supported.
Link is changed in both the header and the footer (since we now have a site map)