### PR TITLE
Remove Google Analytics integration

### DIFF
--- a/themes/navsite/layouts/partials/head.html
+++ b/themes/navsite/layouts/partials/head.html
@@ -19,13 +19,4 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.1.0/js/bootstrap.min.js"></script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-47312122-2', 'uninett.no');
-      ga('send', 'pageview');
-    </script>
 </head>


### PR DESCRIPTION
1. We never use this.
2. It's likely outdated.
3. Sikt is dropping all use of Google Analytics due to legal/privacy issues in Norway/EU.