### PR TITLE
Distinguish links from surrounding text without relying on color

### DIFF
--- a/themes/navsite/static/css/style.css
+++ b/themes/navsite/static/css/style.css
@@ -637,3 +637,8 @@ a:not(.navbar-header a, .navbar-right a, .quick-link-wrapper a, .download-alt a,
 .label-default {
     background-color: #757575 !important;
 }
+
+/* Links surrounded by text */
+p a, #who a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Ensures compliance with WCAG 2.1 - 1.4.11 (Ensure links are distinguished from surrounding text in a way that does not rely on color) by adding underline styling to relevant links to distinguish them from the surrounding text. 
Does not affect links that are not surrounded by text, as they already have sufficient contrast according to WCAG 2. 0 - 1.4.3 and are not covered by WCAG 2.1 - 1.4.11. 